### PR TITLE
Remove Slack reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
 						<p>You can engage in many ways:</p>
 						<ul>
 							<li><strong>Request a change or an addition</strong><br><a href="https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projects=wikimediaui_style_guide" target="_blank" rel="noopener">Raise a ticket on our workboard</a> to request a change to the Style Guide</li>
-							<li><strong>Provide feedback</strong><br>Get in touch with us on <a href="https://meta.wikimedia.org/wiki/IRC/Channels#wikimedia-design" target="_blank" rel="noopener">IRC</a> or Slack</li>
+							<li><strong>Provide feedback</strong><br>Get in touch with us on <a href="https://meta.wikimedia.org/wiki/IRC/Channels#wikimedia-design" target="_blank" rel="noopener">IRC</a></li>
 							<li><strong>Follow us</strong><br>Follow <a href="https://twitter.com/WikimediaUX" target="_blank" rel="noopener">@WikimediaUX on Twitter</a></li>
 							<li><strong>Contribute</strong><br>Read <a href="https://github.com/wikimedia/WikimediaUI-Style-Guide/blob/master/CONTRIBUTING.md" target="_blank" rel="noopener">contributing guidelines on Github</a></li>
 							<li><strong>Play around</strong><br><a href="https://github.com/wikimedia/WikimediaUI-Style-Guide/archive/master.zip" target="_blank" rel="noopener">Download Wikimedia Design Style Guide</a></li>


### PR DESCRIPTION
* We don't use Slack at Wikimedia
* There's no mention of what channel/where/how to join